### PR TITLE
Refine Testing page

### DIFF
--- a/example.md
+++ b/example.md
@@ -2,13 +2,14 @@
 
 ## Description
 
-A description
+An example showing a possible approximate structure for one of our pages. Feel free to use this as a template for creating other pages.
 
-# Technologies
+This page will be removed when we have added sufficient other content.
+
+## Technologies
 
 | Name | Status | Usecase  | Notes  |
 |---|---|---|---|
 | Tech 1 | Recommended | Default choice |  |
 | Tech 2 | Limited use | Legacy applications only | See details here www.example.com |
 | Tech 3 | Do not use  | Not suitable |  |
-| RSpec  | Recommended | Default choice | Testing framework for Ruby/Ruby on Rails. Tests include clear statements explaining how the application is expected to behave. https://github.com/rspec/rspec-rails |  

--- a/testing.md
+++ b/testing.md
@@ -1,7 +1,29 @@
 
-# Technologies
+# Testing
+
+This page lists testing frameworks that are recommended for use with the main programming languages used in LAA Digital.
+
+## Ruby
 
 | Name | Status | Usecase  | Notes  |
 |---|---|---|---|
-| RSpec | Recommended | Default choice | Testing framework for Ruby/Ruby on Rails. Tests include clear statements explaining how the application is expected to behave. https://github.com/rspec/rspec-rails |
-| Tech 2 | Limited use | Legacy applications only | See details|
+| RSpec | Recommended | Default choice | Testing framework for Ruby/Ruby on Rails. Tests include clear statements explaining how the application is expected to behave. RSpec is currently the default choice and is used for all existing applications within the department. https://github.com/rspec/rspec-rails |
+| Minitest | Limited use |  | Developers should aim to use RSpec for consistency with existing applications, however Minitest is a valid alternative and can be used given reasonable justification https://github.com/seattlerb/minitest |
+
+## Python
+
+| Name | Status | Usecase  | Notes  |
+|---|---|---|---|
+|  |  |  |  |
+
+## Java
+
+| Name | Status | Usecase  | Notes  |
+|---|---|---|---|
+|  |  |  |  |
+
+## Oracle
+
+| Name | Status | Usecase  | Notes  |
+|---|---|---|---|
+|  |  |  |  |


### PR DESCRIPTION
* Makes structural changes to the Testing page to allow testing frameworks for multiple languages to be added.

* Adds Minitest to the Ruby section.

We probably need to consider whether this page is solely for unit testing frameworks, or whether we want to consider other types of testing here too. Alternatively other types of testing (eg functional) could have their own pages 