### PR TITLE
Add flake8 linter

### DIFF
--- a/code_linters.md
+++ b/code_linters.md
@@ -22,6 +22,6 @@
 
 | Name | Status | Usecase  | Notes  |
 |---|---|---|---|
-| [Flak8](https://flake8.pycqa.org/en/latest/) | Recommended | Default choice | Wrapper which verifies pep8, pyflakes and circular complexity
-| Tech 2 | Limited use | Legacy applications only | See details|
+| [Flake8](https://flake8.pycqa.org/en/latest/) | Recommended | Default choice | Wrapper which verifies pep8, pyflakes and circular complexity
+
 

--- a/code_linters.md
+++ b/code_linters.md
@@ -17,3 +17,11 @@
 | Name | Status | Usecase  | Notes  |
 |---|---|---|---|
 | Stylelint | Recommended | Default choice | A mighty, modern linter that helps you avoid errors and enforce conventions in your styles, https://stylelint.io/. A version, which should be used, has been configured to comply with GDS style guides: https://github.com/alphagov/stylelint-config-gds |
+
+## Python
+
+| Name | Status | Usecase  | Notes  |
+|---|---|---|---|
+| [Flak8](https://flake8.pycqa.org/en/latest/) | Recommended | Default choice | Wrapper which verifies pep8, pyflakes and circular complexity
+| Tech 2 | Limited use | Legacy applications only | See details|
+


### PR DESCRIPTION
Adding popular python flake8 linter.

We use this across some of our applications:

- https://github.com/ministryofjustice/cla_backend/
- https://github.com/ministryofjustice/cla_frontend
- https://github.com/ministryofjustice/cla_public/