### PR TITLE
Remove boilerplate text from code_linters

### DIFF
--- a/code_linters.md
+++ b/code_linters.md
@@ -5,7 +5,6 @@
 | Name | Status | Usecase  | Notes  |
 |---|---|---|---|
 | RuboCop | Recommended | Default choice | A Ruby code analyser/formatter. Identifies issues and can auto-correct them. https://github.com/rubocop-hq/rubocop. A version, which should be used, has been configured to comply with GDS style guides: https://github.com/alphagov/rubocop-govuk |
-| Tech 2 | Limited use | Legacy applications only | See details|
 
 ## JavaScript
 


### PR DESCRIPTION
## What does this pull request do?

Removes a line of holding text from the code_linters page.