### PR TITLE
Feature: Add template for discussion points

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion_point.md
+++ b/.github/ISSUE_TEMPLATE/discussion_point.md
@@ -1,0 +1,23 @@
+---
+name: Discussion Point
+about: Suggest an area of discussion
+title: 'Discussion Point:'
+labels: question
+assignees: ''
+---
+
+### Summary Of The Question
+
+<!-- In a couple of sentences, please summarise what your question is / what you want to be discussed.--->
+
+### Context
+
+<!-- Here you can put detail about the context to your question. What is the need? What problem does it solve? Is there a discrepancy currently across our tech estate? --->
+
+#### Next Steps
+
+<!-- What would be the next actionable steps based on this discussion? Documentation, testing, proof of concepts? Do you have suggested deadlines to revisit this topic --->
+
+The next actionable steps (with dates and assignees) are to:
+
+- [ ] <!-- Action detail -->


### PR DESCRIPTION
## What does this pull request do?

- Adds an issue template for any discussion points which automatically adds a question label and outlines information needed in a discussion. Comments only show in Raw view.

## Screenshots

![Screenshot 2021-03-29 at 14 46 23](https://user-images.githubusercontent.com/13496774/112846076-89bc0d00-909d-11eb-9173-8a47f59effd5.png)

![Screenshot 2021-03-29 at 14 46 49](https://user-images.githubusercontent.com/13496774/112846131-9c364680-909d-11eb-888f-6c7332d8830d.png)


## Any other changes that would benefit highlighting?

N/A